### PR TITLE
mainpage recently api 구현

### DIFF
--- a/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
@@ -23,6 +23,7 @@ public enum ResponseCodeAndMessage {
 	WEBTOON_TOP_SUCCESS(HttpStatus.OK.value(), "홈 화면용 데이터 조회에 성공했습니다."),
 	WEBTOON_CREATE_SUCCESS(HttpStatus.CREATED.value(), "웹툰 생성에 성공했습니다."),
 	WEBTOON_MAIN_SUCCESS(HttpStatus.OK.value(), "카테고리별 웹툰 목록 조회에 성공했습니다."),
+
 	// 사용자 관련 성공 응답
 	USER_REGISTER_SUCCESS(HttpStatus.CREATED.value(), "회원가입이 성공적으로 완료되었습니다."),
 	USER_LOGIN_SUCCESS(HttpStatus.OK.value(), "로그인이 성공적으로 완료되었습니다."),

--- a/src/main/java/com/akatsuki/newsum/common/security/UserDetailsImpl.java
+++ b/src/main/java/com/akatsuki/newsum/common/security/UserDetailsImpl.java
@@ -20,6 +20,10 @@ public class UserDetailsImpl implements UserDetails {
 		return user.getId();
 	}
 
+	public User getUser() {
+		return user;
+	}
+
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
 		return Collections.emptyList(); // 권한이 필요하면 여기에 ROLE 추가

--- a/src/main/java/com/akatsuki/newsum/common/security/UserDetailsImpl.java
+++ b/src/main/java/com/akatsuki/newsum/common/security/UserDetailsImpl.java
@@ -8,9 +8,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import com.akatsuki.newsum.domain.user.entity.User;
 
-import lombok.Getter;
-
-@Getter
 public class UserDetailsImpl implements UserDetails {
 
 	private final User user;

--- a/src/main/java/com/akatsuki/newsum/common/security/UserDetailsImpl.java
+++ b/src/main/java/com/akatsuki/newsum/common/security/UserDetailsImpl.java
@@ -19,6 +19,10 @@ public class UserDetailsImpl implements UserDetails {
 		this.user = user;
 	}
 
+	public Long getUserId() {
+		return user.getId();
+	}
+
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
 		return Collections.emptyList(); // 권한이 필요하면 여기에 ROLE 추가

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/controller/WebtoonController.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/controller/WebtoonController.java
@@ -147,7 +147,7 @@ public class WebtoonController {
 	public ResponseEntity<ApiResponse<Map<String, List<WebtoonCardDto>>>> getRecentWebtoons(
 		@AuthenticationPrincipal UserDetailsImpl userPrincipal) {
 		Long userId = userPrincipal.getUserId();
-		
+
 		List<WebtoonCardDto> recentWebtoons = webtoonService.getRecentWebtoons(userId);
 
 		return ResponseEntity.ok(ApiResponse.success(

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/controller/WebtoonController.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/controller/WebtoonController.java
@@ -150,6 +150,7 @@ public class WebtoonController {
 		List<WebtoonCardDto> recentWebtoons = webtoonService.getRecentWebtoons(userId);
 
 		return ResponseEntity.ok(ApiResponse.success(
+			ResponseCodeAndMessage.USER_RECENTLY_VIEWED_WEBTOON_LIST_SUCCESS,
 			Map.of("recentWebtoons", recentWebtoons)
 		));
 	}

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/controller/WebtoonController.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/controller/WebtoonController.java
@@ -147,6 +147,7 @@ public class WebtoonController {
 	public ResponseEntity<ApiResponse<Map<String, List<WebtoonCardDto>>>> getRecentWebtoons(
 		@AuthenticationPrincipal UserDetailsImpl userPrincipal) {
 		Long userId = userPrincipal.getUserId();
+		
 		List<WebtoonCardDto> recentWebtoons = webtoonService.getRecentWebtoons(userId);
 
 		return ResponseEntity.ok(ApiResponse.success(

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/controller/WebtoonController.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/controller/WebtoonController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +23,7 @@ import com.akatsuki.newsum.common.pagination.model.cursor.Cursor;
 import com.akatsuki.newsum.common.pagination.model.page.CursorPage;
 import com.akatsuki.newsum.common.security.JwtTokenUtil;
 import com.akatsuki.newsum.common.security.TokenProvider;
+import com.akatsuki.newsum.common.security.UserDetailsImpl;
 import com.akatsuki.newsum.domain.webtoon.dto.CreateWebtoonReqeust;
 import com.akatsuki.newsum.domain.webtoon.dto.WebtoonCardDto;
 import com.akatsuki.newsum.domain.webtoon.dto.WebtoonDetailResponse;
@@ -141,20 +143,15 @@ public class WebtoonController {
 		);
 	}
 
-	//최근조회페이지
 	@GetMapping("/recent")
-	public ResponseEntity<ApiResponse<Map<String, List<WebtoonCardDto>>>> getRecentViewed(
-		@RequestHeader("Authorization") String bearerToken) {
+	public ResponseEntity<ApiResponse<Map<String, List<WebtoonCardDto>>>> getRecentWebtoons(
+		@AuthenticationPrincipal UserDetailsImpl userPrincipal) {
+		Long userId = userPrincipal.getUserId();
+		List<WebtoonCardDto> recentWebtoons = webtoonService.getRecentWebtoons(userId);
 
-		// Long userId = validateTokenAndExtractPrincipal(bearerToken);
-		// List<WebtoonCardDto> recentViewed = webtoonService.getRecentViewedWebtoons(userId);
-		//
-		// return ResponseEntity.ok(
-		// 	ApiResponse.success(ResponseCodeAndMessage.WEBTOON_RECENT_SUCCESS, Map.of(
-		// 		"recentWebtoons", recentViewed
-		// 	))
-		// );
-		return null;
+		return ResponseEntity.ok(ApiResponse.success(
+			Map.of("recentWebtoons", recentWebtoons)
+		));
 	}
 
 }

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/RecentViewQueryRepository.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/RecentViewQueryRepository.java
@@ -1,0 +1,9 @@
+package com.akatsuki.newsum.domain.webtoon.repository;
+
+import java.util.List;
+
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Webtoon;
+
+public interface RecentViewQueryRepository {
+	List<Webtoon> findRecentWebtoonsByUserId(Long userId, int limit);
+}

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/RecentViewQueryRepositoryImpl.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/RecentViewQueryRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.akatsuki.newsum.domain.webtoon.repository;
+
+import java.util.List;
+
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.QRecentView;
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Webtoon;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class RecentViewQueryRepositoryImpl implements RecentViewQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+	private final QRecentView recentView = QRecentView.recentView;
+
+	@Override
+	public List<Webtoon> findRecentWebtoonsByUserId(Long userId, int limit) {
+		return queryFactory
+			.select(recentView.webtoon)
+			.from(recentView)
+			.where(recentView.user.id.eq(userId))
+			.orderBy(recentView.viewedAt.desc())
+			.limit(limit)
+			.fetch();
+	}
+}
+
+

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/RecentViewQueryRepositoryImpl.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/RecentViewQueryRepositoryImpl.java
@@ -1,8 +1,9 @@
 package com.akatsuki.newsum.domain.webtoon.repository;
 
+import static com.akatsuki.newsum.domain.webtoon.entity.webtoon.QRecentView.*;
+
 import java.util.List;
 
-import com.akatsuki.newsum.domain.webtoon.entity.webtoon.QRecentView;
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Webtoon;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -12,16 +13,15 @@ import lombok.RequiredArgsConstructor;
 public class RecentViewQueryRepositoryImpl implements RecentViewQueryRepository {
 
 	private final JPAQueryFactory queryFactory;
-	private final QRecentView recentView = QRecentView.recentView;
 
 	@Override
-	public List<Webtoon> findRecentWebtoonsByUserId(Long userId, int limit) {
+	public List<Webtoon> findRecentWebtoonsByUserId(Long userId, int RECENT_WEBTOON_LIMIT) {
 		return queryFactory
 			.select(recentView.webtoon)
 			.from(recentView)
 			.where(recentView.user.id.eq(userId))
 			.orderBy(recentView.viewedAt.desc())
-			.limit(limit)
+			.limit(RECENT_WEBTOON_LIMIT)
 			.fetch();
 	}
 }

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/RecentViewRepository.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/RecentViewRepository.java
@@ -1,0 +1,9 @@
+package com.akatsuki.newsum.domain.webtoon.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.RecentView;
+
+public interface RecentViewRepository extends JpaRepository<RecentView, Long>, RecentViewQueryRepository {
+}
+

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
@@ -32,7 +32,6 @@ import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Webtoon;
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.WebtoonDetail;
 import com.akatsuki.newsum.domain.webtoon.exception.WebtoonNotFoundException;
 import com.akatsuki.newsum.domain.webtoon.repository.NewsSourceRepository;
-import com.akatsuki.newsum.domain.webtoon.repository.RecentViewQueryRepository;
 import com.akatsuki.newsum.domain.webtoon.repository.WebtoonDetailRepository;
 import com.akatsuki.newsum.domain.webtoon.repository.WebtoonRepository;
 import com.akatsuki.newsum.extern.dto.CreateWebtoonApiRequest;
@@ -52,7 +51,7 @@ public class WebtoonService {
 	private final WebtoonDetailRepository webtoonDetailRepository;
 	private final NewsSourceRepository newsSourceRepository;
 	private final AiServerApiService aiServerApiService;
-	private final RecentViewQueryRepository recentViewQueryRepository;
+	private final RecentViewRepository recentViewRepository;
 
 	private final int RELATED_CATEGORY_SIZE = 2;
 	private final int RELATED_AI_AUTHOR_SIZE = 2;

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
@@ -258,11 +258,8 @@ public class WebtoonService {
 		List<Webtoon> recentWebtoons = recentViewRepository.findRecentWebtoonsByUserId(userId, RECENT_WEBTOON_LIMIT);
 
 		if (recentWebtoons.isEmpty()) {
-			log.warn("최근 웹툰 없음 userId={}", userId);
 			return List.of();
 		}
-
-		log.info("최근 본 웹툰 목록 userId={} : {}", userId, recentWebtoons);
 
 		// 변환 중 오류 발생 시 명확하게 터뜨리는 것이 좋다.
 		return recentWebtoons.stream()

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
@@ -32,6 +32,7 @@ import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Webtoon;
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.WebtoonDetail;
 import com.akatsuki.newsum.domain.webtoon.exception.WebtoonNotFoundException;
 import com.akatsuki.newsum.domain.webtoon.repository.NewsSourceRepository;
+import com.akatsuki.newsum.domain.webtoon.repository.RecentViewQueryRepository;
 import com.akatsuki.newsum.domain.webtoon.repository.WebtoonDetailRepository;
 import com.akatsuki.newsum.domain.webtoon.repository.WebtoonRepository;
 import com.akatsuki.newsum.extern.dto.CreateWebtoonApiRequest;
@@ -51,6 +52,7 @@ public class WebtoonService {
 	private final WebtoonDetailRepository webtoonDetailRepository;
 	private final NewsSourceRepository newsSourceRepository;
 	private final AiServerApiService aiServerApiService;
+	private final RecentViewQueryRepository recentViewQueryRepository;
 
 	private final int RELATED_CATEGORY_SIZE = 2;
 	private final int RELATED_AI_AUTHOR_SIZE = 2;
@@ -242,4 +244,9 @@ public class WebtoonService {
 		return result;
 	}
 
+	public List<WebtoonCardDto> getRecentWebtoons(Long userId) {
+		return recentViewQueryRepository.findRecentWebtoonsByUserId(userId, 3).stream()
+			.map(WebtoonCardDto::toDto)
+			.toList();
+	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#27 

## 📝작업 내용

유저아이디와 토큰을 받아올 경우, 유저id를 통해 최근 본 테이블 3개를 조회합니다. 
## 💬리뷰 요구사항(선택)

저번 pr 때 말씀주셨던 dto에 관련해서 질문이 있습니다.
```java
	public static WebtoonCardDto toDto(Webtoon webtoon) {
		return new WebtoonCardDto(
			webtoon.getId(),
			webtoon.getTitle(),
			webtoon.getThumbnailImageUrl(),
			webtoon.getCreatedAt()
		);
	}
```
위의 부분이였는데, dto 에서 빼서 별도 서비스에서 관리하는게 어떤지 의견주셨는데,
별도 mapperdto class 을 생성해서 관리하면 class 가 많아져서 관리가 어려울지 궁금합니다.

추가로  "Category개수만큼 SQL쿼리문이 발생하는데 한번에 조회할 방법" 의견주셨는데 

카테고리가 적은 경우에 for + 인덱스 활용을하면, 해당 인덱스의 카테고리만 가져올 수 있기때문에
테이블 풀 스캔이 발생하지 않고 거기서 limit을 3개를 걸거라고 생각해서 for 구문이 어떨까요
where 로 카테고리 = 'it' 만 읽고 인덱스 범위 스캔만으로 limit 3 가 추출 가능할 것으로 보입니다

반면 파티셔닝을 사용하면 테이블 풀스캔을 뜬다음 카테고리별로 나눠서 정렬한 후 순위매김을 진행합니다.
이는 카테고리는 적고 웹툰의 양은 수십만건일때 비효율적이라고 생각합니다.

다만 위의 for 구문을 사용하면 5번의 디비연결이 수행되기 때문에 네트워크 비용이 발생할거 같지만
자주 조회하는게 아니라면, 괜찮을거 같습니다(?) 

이부분에 대해서 의견 궁금합니다.

추가로 아래는 포스트맨에서 테스트했을때 결과값입니다

```java
{
    "message": "최근 본 웹툰 목록 조회에 성공했습니다.",
    "code": 200,
    "data": {
        "recentWebtoons": [
            {
                "id": 3,
                "title": "정치와 알고리즘",
                "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/not_image.png",
                "createdAt": "2025-05-07T04:30:46.259509"
            },
            {
                "id": 2,
                "title": "메타버스 대모험",
                "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/not_image.png",
                "createdAt": "2025-05-07T04:30:46.259509"
            },
            {
                "id": 1,
                "title": "AI 혁명",
                "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/not_image.png",
                "createdAt": "2025-05-07T04:30:46.259509"
            }
        ]
    }
}
```

테스트할때, 

```java
@GetMapping("/recent")
	public ResponseEntity<ApiResponse<Map<String, List<WebtoonCardDto>>>> getRecentWebtoons(
		@AuthenticationPrincipal UserDetailsImpl userPrincipal) {
		Long userId = userPrincipal.getUserId();
		
		List<WebtoonCardDto> recentWebtoons = webtoonService.getRecentWebtoons(userId);

		return ResponseEntity.ok(ApiResponse.success(
			ResponseCodeAndMessage.USER_RECENTLY_VIEWED_WEBTOON_LIST_SUCCESS,
			Map.of("recentWebtoons", recentWebtoons)
		));
	}
```

에서 @AuthenticationPrincipal UserDetailsImpl userPrincipal) { 값으로인해 
http://localhost:8080/api/v1/webtoons/recent?userId=2 로 요청해도 요청이 오지 않습니다

테스트 코드로 

```java
@GetMapping("/recent")
public ResponseEntity<ApiResponse<Map<String, List<WebtoonCardDto>>>> getRecentWebtoons(
    @AuthenticationPrincipal UserDetailsImpl userPrincipal) {

    Long userId = (userPrincipal == null) ? 2L : userPrincipal.getUserId();
    List<WebtoonCardDto> recentWebtoons = webtoonService.getRecentWebtoons(userId);

    return ResponseEntity.ok(ApiResponse.success(
        ResponseCodeAndMessage.USER_RECENTLY_VIEWED_WEBTOON_LIST_SUCCESS,
        Map.of("recentWebtoons", recentWebtoons)
    ));
}

```

식으로 테스트 시 위와 같이 변경하여 받아오는 것 확인했습니다.


항상 코드리뷰 해주셔서 감사드립니다 !