### PR TITLE
[#93] 신규회원가입시, 랜덤 닉네임 및 기본 프로필 이미지 설정 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,5 @@ AI_SERVER_BASE_URL=http://localhost:8080
 
 #Server Port
 SERVER_PORT=
+
+default-profile-image-url=

--- a/src/main/java/com/akatsuki/newsum/common/dto/ErrorCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ErrorCodeAndMessage.java
@@ -37,6 +37,7 @@ public enum ErrorCodeAndMessage {
 	// 사용자 관련 클라이언트 오류
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 사용자입니다."),
 	INVALID_USER_CREDENTIALS(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 사용자 인증정보입니다."),
+	DUPLICATE_NICKNAME_GENERATION_FAILED(409, "중복되지 않는 닉네임을 찾을 수 없습니다."),
 
 	// 서버 오류 (5xx)
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
@@ -18,13 +18,20 @@ public class NicknameGenerator {
 
 	public String generate() {
 		Random random = new Random(System.nanoTime());
-		String nickname;
-		do {
+
+		int attempts = 0;
+		int maxAttempts = 20;
+
+		while (attempts++ < maxAttempts) {
 			String base = BASE_NAMES.get(random.nextInt(BASE_NAMES.size()));
 			int suffix = random.nextInt(5000);
-			nickname = base + suffix;
+			String nickname = base + suffix;
 
-		} while (userRepository.existsByNickname(nickname));
-		return nickname;
+			if (!userRepository.existsByNickname(nickname)) {
+				return nickname;
+			}
+		}
+		throw new IllegalStateException("중복되지 않는 닉네임을 찾을 수 없습니다.");
 	}
+
 }

--- a/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
@@ -15,7 +15,6 @@ public class NicknameGenerator {
 
 	private final List<String> BASE_NAMES = List.of("춘식이", "라이언", "무지", "어피치");
 	private final UserRepository userRepository;
-	private final Random random = new Random();
 
 	public String generate() {
 		Random random = new Random(System.nanoTime());

--- a/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
@@ -25,7 +25,7 @@ public class NicknameGenerator {
 			suffix = random.nextInt(1000);
 			nickname = base + suffix;
 		}
-
 		return nickname;
 	}
 }
+

--- a/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
@@ -1,0 +1,31 @@
+package com.akatsuki.newsum.domain.user.generator;
+
+import java.util.List;
+import java.util.Random;
+
+import org.springframework.stereotype.Component;
+
+import com.akatsuki.newsum.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class NicknameGenerator {
+
+	private static final List<String> BASE_NAMES = List.of("춘식이", "라이언", "무지", "어피치");
+	private final UserRepository userRepository;
+	private final Random random = new Random();
+
+	public String generate() {
+		String base = BASE_NAMES.get(random.nextInt(BASE_NAMES.size()));
+		int suffix = random.nextInt(5000);
+		String nickname = base + suffix;
+		while (userRepository.existsByNickname(nickname)) {
+			suffix = random.nextInt(1000);
+			nickname = base + suffix;
+		}
+
+		return nickname;
+	}
+}

--- a/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
@@ -20,9 +20,10 @@ public class NicknameGenerator {
 	public String generate() {
 		String base = BASE_NAMES.get(random.nextInt(BASE_NAMES.size()));
 		int suffix = random.nextInt(5000);
+
 		String nickname = base + suffix;
 		while (userRepository.existsByNickname(nickname)) {
-			suffix = random.nextInt(1000);
+			suffix = random.nextInt(5000);
 			nickname = base + suffix;
 		}
 		return nickname;

--- a/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class NicknameGenerator {
 
-	private static final List<String> BASE_NAMES = List.of("춘식이", "라이언", "무지", "어피치");
+	private final List<String> BASE_NAMES = List.of("춘식이", "라이언", "무지", "어피치");
 	private final UserRepository userRepository;
 	private final Random random = new Random();
 

--- a/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
@@ -5,6 +5,8 @@ import java.util.Random;
 
 import org.springframework.stereotype.Component;
 
+import com.akatsuki.newsum.common.dto.ErrorCodeAndMessage;
+import com.akatsuki.newsum.common.exception.BusinessException;
 import com.akatsuki.newsum.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -31,7 +33,7 @@ public class NicknameGenerator {
 				return nickname;
 			}
 		}
-		throw new IllegalStateException("중복되지 않는 닉네임을 찾을 수 없습니다.");
+		throw new BusinessException(ErrorCodeAndMessage.DUPLICATE_NICKNAME_GENERATION_FAILED);
 	}
 
 }

--- a/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/generator/NicknameGenerator.java
@@ -18,15 +18,14 @@ public class NicknameGenerator {
 	private final Random random = new Random();
 
 	public String generate() {
-		String base = BASE_NAMES.get(random.nextInt(BASE_NAMES.size()));
-		int suffix = random.nextInt(5000);
-
-		String nickname = base + suffix;
-		while (userRepository.existsByNickname(nickname)) {
-			suffix = random.nextInt(5000);
+		Random random = new Random(System.nanoTime());
+		String nickname;
+		do {
+			String base = BASE_NAMES.get(random.nextInt(BASE_NAMES.size()));
+			int suffix = random.nextInt(5000);
 			nickname = base + suffix;
-		}
+
+		} while (userRepository.existsByNickname(nickname));
 		return nickname;
 	}
 }
-

--- a/src/main/java/com/akatsuki/newsum/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/repository/UserRepository.java
@@ -9,6 +9,6 @@ import com.akatsuki.newsum.domain.user.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
 
-	boolean existsByNickname(String nickname); // ✅ 닉네임 중복 확인
+	boolean existsByNickname(String nickname);
 
 }

--- a/src/main/java/com/akatsuki/newsum/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/repository/UserRepository.java
@@ -8,4 +8,7 @@ import com.akatsuki.newsum.domain.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
+
+	boolean existsByNickname(String nickname); // ✅ 닉네임 중복 확인
+
 }

--- a/src/main/java/com/akatsuki/newsum/domain/user/service/GoogleOAuthService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/service/GoogleOAuthService.java
@@ -21,6 +21,7 @@ import com.akatsuki.newsum.domain.user.entity.SocialLogin;
 import com.akatsuki.newsum.domain.user.entity.Status;
 import com.akatsuki.newsum.domain.user.entity.User;
 import com.akatsuki.newsum.domain.user.entity.UserRole;
+import com.akatsuki.newsum.domain.user.generator.NicknameGenerator;
 import com.akatsuki.newsum.domain.user.repository.SocialLoginRepository;
 import com.akatsuki.newsum.domain.user.repository.UserRepository;
 
@@ -33,6 +34,7 @@ public class GoogleOAuthService {
 	private final UserRepository userRepository;
 	private final SocialLoginRepository socialLoginRepository;
 	private final TokenProvider tokenProvider;
+	private final NicknameGenerator nicknameGenerator;
 
 	@Value("${GOOGLE_CLIENT_ID}")
 	private String clientId;
@@ -42,6 +44,9 @@ public class GoogleOAuthService {
 
 	@Value("${GOOGLE_REDIRECT_URI}")
 	private String redirectUri;
+
+	@Value("${user.default-profile-image-url}")
+	private String defaultProfileImageUrl;
 
 	private final RestTemplate restTemplate = new RestTemplate();
 
@@ -115,10 +120,11 @@ public class GoogleOAuthService {
 	}
 
 	private User saveNewUser(GoogleUserInfo userInfo) {
+		String nickname = nicknameGenerator.generate();
 		return userRepository.save(User.builder()
 			.email(userInfo.getEmail())
-			.nickname(userInfo.getName())
-			.profileImageUrl(userInfo.getPicture())
+			.nickname(nickname)
+			.profileImageUrl(defaultProfileImageUrl)
 			.role(UserRole.USER_BASIC)
 			.status(Status.ACTIVATE)
 			.build());

--- a/src/main/java/com/akatsuki/newsum/domain/user/service/KakaoOAuthService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/service/KakaoOAuthService.java
@@ -22,6 +22,7 @@ import com.akatsuki.newsum.domain.user.entity.SocialLogin;
 import com.akatsuki.newsum.domain.user.entity.Status;
 import com.akatsuki.newsum.domain.user.entity.User;
 import com.akatsuki.newsum.domain.user.entity.UserRole;
+import com.akatsuki.newsum.domain.user.generator.NicknameGenerator;
 import com.akatsuki.newsum.domain.user.repository.SocialLoginRepository;
 import com.akatsuki.newsum.domain.user.repository.UserRepository;
 
@@ -34,6 +35,7 @@ public class KakaoOAuthService {
 	private final SocialLoginRepository socialLoginRepository;
 	private final TokenProvider tokenProvider;
 	private final RestTemplate restTemplate = new RestTemplate();
+	private final NicknameGenerator nicknameGenerator;
 
 	@Value("${KAKAO_CLIENT_ID}")
 	private String clientId;
@@ -43,6 +45,9 @@ public class KakaoOAuthService {
 
 	@Value("${KAKAO_REDIRECT_URI}")
 	private String redirectUri;
+
+	@Value("${user.default-profile-image-url}")
+	private String defaultProfileImageUrl;
 
 	public TokenResponse loginWithCode(String code) {
 		String accessToken = getAccessToken(code);
@@ -98,10 +103,11 @@ public class KakaoOAuthService {
 	}
 
 	private User saveNewUser(OAuthUserInfo userInfo) {
+		String nickname = nicknameGenerator.generate();
 		return userRepository.save(User.builder()
 			.email(userInfo.getEmail())
-			.nickname(userInfo.getName())
-			.profileImageUrl(userInfo.getPicture())
+			.nickname(nickname)
+			.profileImageUrl(defaultProfileImageUrl)
 			.role(UserRole.USER_BASIC)
 			.status(Status.ACTIVATE)
 			.build());

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -62,3 +62,7 @@ jwt:
 
 ai-server:
   base-url: ${AI_SERVER_BASE_URL}
+
+user:
+  default-profile-image-url: ${default-profile-image-url}
+

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,26 +2,23 @@ spring:
   config:
     activate:
       on-profile: local
-  # 데이터베이스 설정 (PostgreSQL)
+
   datasource:
     url: ${DB_URL}
-    driverClassName: ${DB_DRIVER}
+    driver-class-name: ${DB_DRIVER}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
-  # JPA 설정
   jpa:
     hibernate:
       ddl-auto: validate
     show-sql: true
 
-  # Redis 설정
   data:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 
-  # Security 설정
   security:
     oauth2:
       client:
@@ -51,6 +48,11 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration
+
 jwt:
   secret: ${JWT_SECRET_KEY}
   access-token:
@@ -60,5 +62,3 @@ jwt:
 
 ai-server:
   base-url: ${AI_SERVER_BASE_URL}
-#server:
-#  port: ${SERVER_PORT}

--- a/src/main/resources/db/migration/V3__Alter_table_webtoon_title.sql
+++ b/src/main/resources/db/migration/V3__Alter_table_webtoon_title.sql
@@ -1,4 +1,3 @@
 alter table public.webtoon
-alter
-column title type varchar(100) using title::varchar(100);
-
+    alter
+        column title type varchar(100) using title::varchar(100);

--- a/src/main/resources/db/migration/V4__Alter_users_profile_image_url_to_text.sql
+++ b/src/main/resources/db/migration/V4__Alter_users_profile_image_url_to_text.sql
@@ -1,3 +1,4 @@
 ALTER TABLE users
-ALTER
-COLUMN profile_image_url TYPE text;
+    ALTER
+        COLUMN profile_image_url TYPE text;
+

--- a/src/main/resources/db/migration/V4__Alter_users_profile_image_url_to_text.sql
+++ b/src/main/resources/db/migration/V4__Alter_users_profile_image_url_to_text.sql
@@ -1,4 +1,3 @@
 ALTER TABLE users
-    ALTER
-        COLUMN profile_image_url TYPE text;
+    ALTER COLUMN profile_image_url TYPE text;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#93 

## 📝작업 내용

신규 회원은 기존 소셜로그인의 본명과 프로필 사진이 아닌, Newsum 기본 프로필 이미지와, 랜덤 닉네임을 사용합니다.
라이언, 춘식이, 무지, 어피지 와 랜덤숫자 1~5000 중에 부여됩니다.
![image](https://github.com/user-attachments/assets/d9f82122-5f80-4792-bac3-56568ef4e41a)

## 💬리뷰 요구사항(선택)
generator 를 클래스를 어디에 둬야할지 애매하여, 패키지를 새로 생성하여 넣었습니다.

구현이 늦어져서 죄송합니다. 리뷰 감사드립니다 !
