### PR TITLE
[#124] Top3에서 오늘일자 외의 웹툰도 가져오도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,3 +92,5 @@ clean {
 test {
     useJUnitPlatform()
 }
+
+

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/WebtoonQueryRepositoryImpl.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/WebtoonQueryRepositoryImpl.java
@@ -68,7 +68,7 @@ public class WebtoonQueryRepositoryImpl implements WebtoonQueryRepository {
 			.join(webtoon).fetchJoin()
 			.on(webtoon.id.eq(recentView.webtoon.id))
 			.where(recentView.user.id.eq(id))
-			.orderBy(recentView.viewedAt.asc())
+			.orderBy(recentView.viewedAt.desc())
 			.fetch();
 	}
 
@@ -81,24 +81,49 @@ public class WebtoonQueryRepositoryImpl implements WebtoonQueryRepository {
 	@Override
 	public List<Webtoon> findTop3TodayByViewCount() {
 		LocalDateTime startOfToday = LocalDateTime.now().toLocalDate().atStartOfDay();
-
-		return queryFactory
+		List<Webtoon> todayTop3Webtoons = queryFactory
 			.selectFrom(webtoon)
 			.where(webtoon.createdAt.goe(startOfToday))
 			.orderBy(webtoon.viewCount.desc())
 			.limit(3)
 			.fetch();
+
+		if (todayTop3Webtoons.size() < 3) {
+			LocalDateTime startOfYesterday = startOfToday.minusDays(1);
+			return queryFactory
+				.selectFrom(webtoon)
+				.where(webtoon.createdAt.goe(startOfYesterday))
+				.orderBy(webtoon.viewCount.desc())
+				.limit(3)
+				.fetch();
+		}
+		return todayTop3Webtoons;
 	}
 
 	@Override
 	public List<Webtoon> findTodayNewsTop3() {
 		LocalDateTime startOfToday = LocalDateTime.now().toLocalDate().atStartOfDay();
 
-		return queryFactory
+		List<Webtoon> todayWebtoons = queryFactory
 			.selectFrom(webtoon)
 			.where(webtoon.createdAt.goe(startOfToday))
 			.orderBy(webtoon.createdAt.desc())
 			.limit(3)
 			.fetch();
+
+		if (todayWebtoons.size() < 3) {
+			LocalDateTime startOfYesterday = startOfToday.minusDays(1);
+
+			return queryFactory
+				.selectFrom(webtoon)
+				.where(webtoon.createdAt.goe(startOfYesterday))
+				.orderBy(webtoon.createdAt.desc())
+				.limit(3)
+				.fetch();
+		}
+
+		return todayWebtoons;
+
 	}
+
 }

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/WebtoonQueryRepositoryImpl.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/WebtoonQueryRepositoryImpl.java
@@ -114,26 +114,12 @@ public class WebtoonQueryRepositoryImpl implements WebtoonQueryRepository {
 	public List<Webtoon> findTodayNewsTop3() {
 		LocalDateTime startOfToday = LocalDateTime.now().toLocalDate().atStartOfDay();
 
-		List<Webtoon> todayWebtoons = queryFactory
+		return queryFactory
 			.selectFrom(webtoon)
 			.where(webtoon.createdAt.goe(startOfToday))
 			.orderBy(webtoon.createdAt.desc())
 			.limit(3)
 			.fetch();
-
-		if (todayWebtoons.size() < 3) {
-			LocalDateTime startOfYesterday = startOfToday.minusDays(1);
-
-			return queryFactory
-				.selectFrom(webtoon)
-				.where(webtoon.createdAt.goe(startOfYesterday))
-				.orderBy(webtoon.createdAt.desc())
-				.limit(3)
-				.fetch();
-		}
-
-		return todayWebtoons;
-
 	}
 
 }

--- a/src/test/java/com/akatsuki/newsum/domain/webtoon/repository/WebtoonQueryRepositoryImplTest.java
+++ b/src/test/java/com/akatsuki/newsum/domain/webtoon/repository/WebtoonQueryRepositoryImplTest.java
@@ -1,0 +1,78 @@
+package com.akatsuki.newsum.domain.webtoon.repository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.akatsuki.newsum.domain.aiAuthor.entity.AiAuthor;
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Category;
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.QWebtoon;
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Webtoon;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@ExtendWith(MockitoExtension.class)
+class WebtoonQueryRepositoryImplTest {
+
+	@Mock
+	private JPAQueryFactory queryFactory;
+
+	@Mock
+	private JPAQuery<Webtoon> query;
+
+	@InjectMocks
+	private WebtoonQueryRepositoryImpl repository;
+
+	@Test
+	@DisplayName("오늘 웹툰이 3개 이상이면 그대로 반환")
+	void todayWebtoonEnough() {
+		// given
+		List<Webtoon> todayWebtoons = List.of(
+			createWebtoon("A"),
+			createWebtoon("B"),
+			createWebtoon("C")
+		);
+
+		// QueryDSL mocking 흐름
+		given(queryFactory.selectFrom(QWebtoon.webtoon)).willReturn(query);
+		given(query.where(any(Predicate.class))).willReturn(query);
+		given(query.orderBy(any(OrderSpecifier.class))).willReturn(query);
+		given(query.limit(anyLong())).willReturn(query);
+		given(query.fetch()).willReturn(todayWebtoons);
+
+		// when
+		List<Webtoon> result = repository.findTodayNewsTop3();
+
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result).extracting(Webtoon::getTitle).containsExactly("A", "B", "C");
+	}
+
+	private Webtoon createWebtoon(String title) {
+		AiAuthor author = mock(AiAuthor.class);
+
+		Webtoon webtoon = new Webtoon(
+			author,
+			Category.IT,
+			title,
+			"dummy content",
+			"https://example.com/image.jpg"
+		);
+
+		ReflectionTestUtils.setField(webtoon, "createdAt", LocalDateTime.now());
+		return webtoon;
+	}
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#124

## 📝작업 내용
topToons 에서 오늘일자 3개가 채워지지 않을 경우, 그 전날 웹툰도 조회하여 총 3개를 가져도록 수정했습니다.

![image](https://github.com/user-attachments/assets/719ff3c4-c326-4e99-b140-538c180b5854)

## 💬리뷰 요구사항(선택)
반복문이 계속해서 발생할 것을 고려하여 3개를 채우기 전까지 그 전날로 이동하는 것의 대한 제한을 최대 10일로 두었습니다.
코드가 좀 길어졌는데, 더 깔끔한 방안이 있으면 의견주시면 감사하겠습니다!

감사합니다.