### PR TITLE
[#101] 사용자 키워드 등록 API 구현

### DIFF
--- a/src/main/java/com/akatsuki/newsum/common/dto/ErrorCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ErrorCodeAndMessage.java
@@ -42,7 +42,10 @@ public enum ErrorCodeAndMessage {
 	// 서버 오류 (5xx)
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다."),
 	NOT_IMPLEMENTED(HttpStatus.NOT_IMPLEMENTED.value(), "아직 구현되지 않은 기능입니다."),
-	SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE.value(), "서비스를 일시적으로 사용할 수 없습니다.");
+	SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE.value(), "서비스를 일시적으로 사용할 수 없습니다."),
+
+	//구독관련 오류
+	KEYWORD_ALREADY_SUBSCRIBED(HttpStatus.CONFLICT.value(), "이미 구독한 키워드입니다.");
 
 	private final int code;
 	private final String message;

--- a/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
@@ -44,7 +44,9 @@ public enum ResponseCodeAndMessage {
 
 	//알림
 	NOTI_LIST_SUCCESS(HttpStatus.OK.value(), "알림 목록 조회에 성공했습니다."),
-	;
+
+	//키워드 성공 응답
+	KEYWORD_SUBSCRIBE_SUCCESS(HttpStatus.OK.value(), "키워드 구독에 성공했습니다.");
 
 	private final int code;
 	private final String message;

--- a/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
@@ -36,6 +36,7 @@ public enum ResponseCodeAndMessage {
 	COMMENT_DELETE_SUCCESS(HttpStatus.NO_CONTENT.value(), "댓글 삭제에 성공했습니다."),
 	COMMEND_EDIT_SUCCESS(HttpStatus.OK.value(), "댓글 수정에 성공했습니다."),
 	COMMENT_ADD_SUCCESS(HttpStatus.CREATED.value(), "댓글 생성에 성공했습니다."),
+	COMMENT_LIKE_TOGGLE_SUCCESS(HttpStatus.OK.value(), "댓글 좋아요에 성공했습니다."),
 
 	//좋아요 관련 성공 응답
 	ARTICLE_LIKE_CHECK_SUCCESS(HttpStatus.OK.value(), "웹툰 좋아요 여부 조회에 성공했습니다."),

--- a/src/main/java/com/akatsuki/newsum/domain/user/controller/UserController.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/controller/UserController.java
@@ -24,6 +24,7 @@ import com.akatsuki.newsum.domain.user.dto.UpdateUserRequestDto;
 import com.akatsuki.newsum.domain.user.dto.UpdateUserResponseDto;
 import com.akatsuki.newsum.domain.user.dto.UserFavoriteWebtoonsResponse;
 import com.akatsuki.newsum.domain.user.dto.UserProfileDto;
+import com.akatsuki.newsum.domain.user.service.KeywordService;
 import com.akatsuki.newsum.domain.user.service.UserService;
 import com.akatsuki.newsum.domain.webtoon.dto.KeywordSubscriptionRequest;
 import com.akatsuki.newsum.domain.webtoon.dto.WebtoonCardDto;
@@ -39,6 +40,7 @@ public class UserController {
 
 	private final UserService userService;
 	private final WebtoonService webtoonService;
+	private final KeywordService keywordService;
 
 	@GetMapping("/profile")
 	public ResponseEntity<ApiResponse<UserProfileDto>> getProfile(
@@ -115,7 +117,7 @@ public class UserController {
 		@RequestBody @Valid KeywordSubscriptionRequest request
 	) {
 		Long userId = getUserId(userDetails);
-		webtoonService.subscribeKeyword(userId, request.keyword());
+		keywordService.subscribeKeyword(userId, request.keyword());
 
 		return ResponseEntity.ok(
 			ApiResponse.success(ResponseCodeAndMessage.KEYWORD_SUBSCRIBE_SUCCESS, null)

--- a/src/main/java/com/akatsuki/newsum/domain/user/controller/UserController.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/controller/UserController.java
@@ -26,7 +26,6 @@ import com.akatsuki.newsum.domain.user.dto.UserFavoriteWebtoonsResponse;
 import com.akatsuki.newsum.domain.user.dto.UserProfileDto;
 import com.akatsuki.newsum.domain.user.service.UserService;
 import com.akatsuki.newsum.domain.webtoon.dto.KeywordSubscriptionRequest;
-import com.akatsuki.newsum.domain.webtoon.dto.KeywordSubscriptionResponse;
 import com.akatsuki.newsum.domain.webtoon.dto.WebtoonCardDto;
 import com.akatsuki.newsum.domain.webtoon.service.WebtoonService;
 
@@ -118,11 +117,9 @@ public class UserController {
 		Long userId = getUserId(userDetails);
 		webtoonService.subscribeKeyword(userId, request.keyword());
 
-
 		return ResponseEntity.ok(
 			ApiResponse.success(ResponseCodeAndMessage.KEYWORD_SUBSCRIBE_SUCCESS, null)
 		);
-	}
 	}
 
 }

--- a/src/main/java/com/akatsuki/newsum/domain/user/controller/UserController.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,6 +25,8 @@ import com.akatsuki.newsum.domain.user.dto.UpdateUserResponseDto;
 import com.akatsuki.newsum.domain.user.dto.UserFavoriteWebtoonsResponse;
 import com.akatsuki.newsum.domain.user.dto.UserProfileDto;
 import com.akatsuki.newsum.domain.user.service.UserService;
+import com.akatsuki.newsum.domain.webtoon.dto.KeywordSubscriptionRequest;
+import com.akatsuki.newsum.domain.webtoon.dto.KeywordSubscriptionResponse;
 import com.akatsuki.newsum.domain.webtoon.dto.WebtoonCardDto;
 import com.akatsuki.newsum.domain.webtoon.service.WebtoonService;
 
@@ -69,7 +72,7 @@ public class UserController {
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@Valid @RequestBody UpdateUserRequestDto dto
 	) {
-		Long userId = userDetails.getUserId();
+		Long userId = getUserId(userDetails);
 		UpdateUserResponseDto responseDto = userService.updateUser(userId, dto);
 
 		return ResponseEntity.ok(
@@ -106,4 +109,20 @@ public class UserController {
 		);
 
 	}
+
+	@PostMapping("/keywords/subscriptions")
+	public ResponseEntity<ApiResponse> addKeyword(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@RequestBody @Valid KeywordSubscriptionRequest request
+	) {
+		Long userId = getUserId(userDetails);
+		webtoonService.subscribeKeyword(userId, request.keyword());
+
+
+		return ResponseEntity.ok(
+			ApiResponse.success(ResponseCodeAndMessage.KEYWORD_SUBSCRIBE_SUCCESS, null)
+		);
+	}
+	}
+
 }

--- a/src/main/java/com/akatsuki/newsum/domain/user/controller/UserController.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/controller/UserController.java
@@ -81,14 +81,6 @@ public class UserController {
 		);
 	}
 
-	private Long getUserId(
-		UserDetailsImpl userDetails) {
-		if (userDetails == null) {
-			return null;
-		}
-		return userDetails.getUserId();
-	}
-
 	@GetMapping("/favorites/webtoons")
 	public ResponseEntity<ApiResponse<UserFavoriteWebtoonsResponse>> getBookmarkedWebtoons(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -124,4 +116,11 @@ public class UserController {
 		);
 	}
 
+	private Long getUserId(
+		UserDetailsImpl userDetails) {
+		if (userDetails == null) {
+			return null;
+		}
+		return userDetails.getUserId();
+	}
 }

--- a/src/main/java/com/akatsuki/newsum/domain/user/entity/User.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/entity/User.java
@@ -6,6 +6,8 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import com.akatsuki.newsum.common.entity.BaseTimeEntity;
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Keyword;
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.KeywordFavorite;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -67,8 +69,12 @@ public class User extends BaseTimeEntity {
 	public void profileImageUrl(String profileImageUrl) {
 		this.profileImageUrl = profileImageUrl;
 	}
-
+	
 	public User(Long id) {
 		this.id = id;
+	}
+
+	public KeywordFavorite subscribeKeyword(Keyword keyword) {
+		return new KeywordFavorite(this, keyword);
 	}
 }

--- a/src/main/java/com/akatsuki/newsum/domain/user/service/KeywordService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/service/KeywordService.java
@@ -23,7 +23,6 @@ public class KeywordService {
 	private final KeywordRepository keywordRepository;
 	private final UserRepository userRepository;
 
-	@Transactional
 	public void subscribeKeyword(Long userId, String keywordContent) {
 		User user = new User(userId);
 		Keyword keyword = keywordRepository.findByContent(keywordContent)

--- a/src/main/java/com/akatsuki/newsum/domain/user/service/KeywordService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/service/KeywordService.java
@@ -1,0 +1,32 @@
+package com.akatsuki.newsum.domain.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.akatsuki.newsum.domain.user.entity.User;
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Keyword;
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.KeywordFavorite;
+import com.akatsuki.newsum.domain.webtoon.repository.KeywordFavoriteRepository;
+import com.akatsuki.newsum.domain.webtoon.repository.KeywordRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class KeywordService {
+	private final KeywordFavoriteRepository keywordFavoriteRepository;
+	private final KeywordRepository keywordRepository;
+
+	@Transactional(readOnly = false)
+	public void subscribeKeyword(Long userId, String keywordContent) {
+		User user = new User(userId);
+
+		Keyword keyword = keywordRepository.findByContent(keywordContent)
+			.orElseGet(() -> keywordRepository.save(new Keyword(keywordContent)));
+
+		KeywordFavorite favorite = user.subscribeKeyword(keyword);
+		keywordFavoriteRepository.save(favorite);
+	}
+
+}

--- a/src/main/java/com/akatsuki/newsum/domain/user/service/KeywordService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/service/KeywordService.java
@@ -1,9 +1,13 @@
 package com.akatsuki.newsum.domain.user.service;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.akatsuki.newsum.common.dto.ErrorCodeAndMessage;
+import com.akatsuki.newsum.common.exception.BusinessException;
 import com.akatsuki.newsum.domain.user.entity.User;
+import com.akatsuki.newsum.domain.user.repository.UserRepository;
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Keyword;
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.KeywordFavorite;
 import com.akatsuki.newsum.domain.webtoon.repository.KeywordFavoriteRepository;
@@ -17,16 +21,21 @@ import lombok.RequiredArgsConstructor;
 public class KeywordService {
 	private final KeywordFavoriteRepository keywordFavoriteRepository;
 	private final KeywordRepository keywordRepository;
+	private final UserRepository userRepository;
 
-	@Transactional(readOnly = false)
+	@Transactional
 	public void subscribeKeyword(Long userId, String keywordContent) {
 		User user = new User(userId);
-
 		Keyword keyword = keywordRepository.findByContent(keywordContent)
 			.orElseGet(() -> keywordRepository.save(new Keyword(keywordContent)));
 
-		KeywordFavorite favorite = user.subscribeKeyword(keyword);
-		keywordFavoriteRepository.save(favorite);
+		try {
+			KeywordFavorite favorite = user.subscribeKeyword(keyword);
+			keywordFavoriteRepository.save(favorite);
+		} catch (DataIntegrityViolationException e) {
+			throw new BusinessException(ErrorCodeAndMessage.KEYWORD_ALREADY_SUBSCRIBED);
+
+		}
 	}
 
 }

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/dto/KeywordSubscriptionRequest.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/dto/KeywordSubscriptionRequest.java
@@ -1,0 +1,9 @@
+package com.akatsuki.newsum.domain.webtoon.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KeywordSubscriptionRequest(
+	@NotBlank
+	String keyword
+) {
+}

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/dto/KeywordSubscriptionResponse.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/dto/KeywordSubscriptionResponse.java
@@ -1,7 +1,6 @@
 package com.akatsuki.newsum.domain.webtoon.dto;
 
 public record KeywordSubscriptionResponse(
-	String keyword,
-
-)
-{}
+	String keyword
+) {
+}

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/dto/KeywordSubscriptionResponse.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/dto/KeywordSubscriptionResponse.java
@@ -1,0 +1,7 @@
+package com.akatsuki.newsum.domain.webtoon.dto;
+
+public record KeywordSubscriptionResponse(
+	String keyword,
+
+)
+{}

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/entity/webtoon/Keyword.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/entity/webtoon/Keyword.java
@@ -1,0 +1,30 @@
+package com.akatsuki.newsum.domain.webtoon.entity.webtoon;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "keyword")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Keyword {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true, length = 100)
+	private String content;
+
+	public Keyword(String content) {
+		this.content = content;
+	}
+
+}

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/entity/webtoon/KeywordFavorite.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/entity/webtoon/KeywordFavorite.java
@@ -1,0 +1,45 @@
+package com.akatsuki.newsum.domain.webtoon.entity.webtoon;
+
+import java.time.LocalDateTime;
+
+import com.akatsuki.newsum.domain.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "keyword_favorite")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KeywordFavorite {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "keyword_id", nullable = false)
+	private Keyword keyword;
+
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	public KeywordFavorite(User user, Keyword keyword) {
+		this.user = user;
+		this.keyword = keyword;
+		this.createdAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/entity/webtoon/KeywordFavorite.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/entity/webtoon/KeywordFavorite.java
@@ -37,9 +37,10 @@ public class KeywordFavorite {
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
 
-	public KeywordFavorite(User user, Keyword keyword) {
-		this.user = user;
+	public KeywordFavorite(User userId, Keyword keyword) {
+		this.user = userId;
 		this.keyword = keyword;
 		this.createdAt = LocalDateTime.now();
 	}
+
 }

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/KeywordFavoriteRepository.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/KeywordFavoriteRepository.java
@@ -1,4 +1,8 @@
 package com.akatsuki.newsum.domain.webtoon.repository;
 
-public interface KeywordFavoriteRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.KeywordFavorite;
+
+public interface KeywordFavoriteRepository extends JpaRepository<KeywordFavorite, Long> {
 }

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/KeywordFavoriteRepository.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/KeywordFavoriteRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.KeywordFavorite;
 
 public interface KeywordFavoriteRepository extends JpaRepository<KeywordFavorite, Long> {
+	boolean existsByUserIdAndKeywordId(Long userId, Long keywordId);
 }

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/KeywordFavoriteRepository.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/KeywordFavoriteRepository.java
@@ -1,0 +1,4 @@
+package com.akatsuki.newsum.domain.webtoon.repository;
+
+public interface KeywordFavoriteRepository {
+}

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/KeywordRepository.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/KeywordRepository.java
@@ -1,4 +1,11 @@
 package com.akatsuki.newsum.domain.webtoon.repository;
 
-public interface KeywordRepository {
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Keyword;
+
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+	Optional<Keyword> findByContent(String keywordContent);
 }

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/KeywordRepository.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/KeywordRepository.java
@@ -1,0 +1,4 @@
+package com.akatsuki.newsum.domain.webtoon.repository;
+
+public interface KeywordRepository {
+}

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
@@ -36,8 +36,6 @@ import com.akatsuki.newsum.domain.webtoon.dto.WebtoonResponse;
 import com.akatsuki.newsum.domain.webtoon.dto.WebtoonSlideDto;
 import com.akatsuki.newsum.domain.webtoon.dto.WebtoonSourceDto;
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Category;
-import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Keyword;
-import com.akatsuki.newsum.domain.webtoon.entity.webtoon.KeywordFavorite;
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.NewsSource;
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.RecentView;
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.Webtoon;
@@ -45,8 +43,6 @@ import com.akatsuki.newsum.domain.webtoon.entity.webtoon.WebtoonDetail;
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.WebtoonFavorite;
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.WebtoonLike;
 import com.akatsuki.newsum.domain.webtoon.exception.WebtoonNotFoundException;
-import com.akatsuki.newsum.domain.webtoon.repository.KeywordFavoriteRepository;
-import com.akatsuki.newsum.domain.webtoon.repository.KeywordRepository;
 import com.akatsuki.newsum.domain.webtoon.repository.NewsSourceRepository;
 import com.akatsuki.newsum.domain.webtoon.repository.RecentViewRepository;
 import com.akatsuki.newsum.domain.webtoon.repository.WebtoonDetailRepository;
@@ -75,8 +71,6 @@ public class WebtoonService {
 	private final WebtoonFavoriteRepository webtoonFavoriteRepository;
 	private final WebtoonLikeRepository webtoonLikeRepository;
 	private final CursorPaginationService cursorPaginationService;
-	private final KeywordRepository keywordRepository;
-	private final KeywordFavoriteRepository keywordFavoriteRepository;
 
 	private final int RECENT_WEBTOON_LIMIT = 4;
 	private final int RELATED_CATEGORY_SIZE = 2;
@@ -415,16 +409,5 @@ public class WebtoonService {
 		long count = webtoonLikeRepository.countByWebtoonId(webtoonId);
 
 		return new WebtoonLikeStatusDto(liked, count);
-	}
-
-	@Transactional(readOnly = false)
-	public void subscribeKeyword(Long userId, String keywordContent) {
-		User user = new User(userId);
-
-		Keyword keyword = keywordRepository.findByContent(keywordContent)
-			.orElseGet(() -> keywordRepository.save(new Keyword(keywordContent)));
-
-		KeywordFavorite favorite = user.subscribeKeyword(keyword);
-		keywordFavoriteRepository.save(favorite);
 	}
 }

--- a/src/main/resources/db/migration/V2025.06.02.1__Create_keyword_and_keyword_favorite.sql
+++ b/src/main/resources/db/migration/V2025.06.02.1__Create_keyword_and_keyword_favorite.sql
@@ -1,0 +1,21 @@
+CREATE TABLE keyword
+(
+    id      BIGSERIAL PRIMARY KEY,
+    content VARCHAR(100) NOT NULL UNIQUE
+);
+
+CREATE TABLE keyword_favorite
+(
+    id         BIGSERIAL PRIMARY KEY,
+    user_id    BIGINT    NOT NULL,
+    keyword_id BIGINT    NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_keyword_favorite_user
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+
+    CONSTRAINT fk_keyword_favorite_keyword
+        FOREIGN KEY (keyword_id) REFERENCES keyword (id) ON DELETE CASCADE,
+
+    CONSTRAINT unique_user_keyword UNIQUE (user_id, keyword_id)
+);


### PR DESCRIPTION
## #️⃣연관된 이슈
#101 

## 📝작업 내용
로그인한 사용자가 키워드를 등록할 수 있습니다.
사용자의 키워드를 keyword, keyword_favorite 테이블에 각각 저장하여, 관련 키워드에 대한 웹툰을 검색하도록 구현할 예정입니다.
![image](https://github.com/user-attachments/assets/0122ccc7-329b-4200-b2e2-2dde9cbd140d)

## 💬리뷰 요구사항(선택)
1. API 명세서에 따라 user 에 컨트롤러를 사용했고, 서비스는 webtoon 를 이용했습니다. 따로 서비스를 분리하는 게 맞을까요?..
2. 서비스 부분에서 keywoedRepository 로 중복되는 걸 찾는 로직이 있는데, 분리하는게 좋을까요?................ 조회쿼리, 저장쿼리 두번나가는데
이걸 최소한으로 할 방법을 찾는게 좋을까요?


리뷰 감사드립니다.