### PR TITLE
[#104] 키워드 북마크 삭제 API 구현

### DIFF
--- a/src/main/java/com/akatsuki/newsum/common/dto/ErrorCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ErrorCodeAndMessage.java
@@ -45,8 +45,8 @@ public enum ErrorCodeAndMessage {
 	SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE.value(), "서비스를 일시적으로 사용할 수 없습니다."),
 
 	//구독관련 오류
-	KEYWORD_ALREADY_SUBSCRIBED(HttpStatus.CONFLICT.value(), "이미 구독한 키워드입니다.");
-
+	KEYWORD_ALREADY_SUBSCRIBED(HttpStatus.CONFLICT.value(), "이미 구독한 키워드입니다."),
+	KEYWORD_SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 키워드입니다.");
 	private final int code;
 	private final String message;
 

--- a/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
@@ -47,8 +47,7 @@ public enum ResponseCodeAndMessage {
 	NOTI_LIST_SUCCESS(HttpStatus.OK.value(), "알림 목록 조회에 성공했습니다."),
 
 	//키워드 성공 응답
-	KEYWORD_SUBSCRIBE_SUCCESS(HttpStatus.OK.value(), "키워드 구독에 성공했습니다."),
-	KEYWORD_SUBSCRIBE_DELETE_SUCCESS(HttpStatus.NO_CONTENT.value(), "키워드 구독에 삭제에 성공했습니다.");
+	KEYWORD_SUBSCRIBE_SUCCESS(HttpStatus.OK.value(), "키워드 구독에 성공했습니다.");
 
 	private final int code;
 	private final String message;

--- a/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
@@ -48,7 +48,7 @@ public enum ResponseCodeAndMessage {
 
 	//키워드 성공 응답
 	KEYWORD_SUBSCRIBE_SUCCESS(HttpStatus.OK.value(), "키워드 구독에 성공했습니다."),
-	KEYWORD_SUBSCRIBE_DELETE_SUCCESS(HttpStatus.OK.value(), "키워드 구독에 삭제에 성공했습니다.");
+	KEYWORD_SUBSCRIBE_DELETE_SUCCESS(HttpStatus.NO_CONTENT.value(), "키워드 구독에 삭제에 성공했습니다.");
 
 	private final int code;
 	private final String message;

--- a/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
@@ -47,7 +47,8 @@ public enum ResponseCodeAndMessage {
 	NOTI_LIST_SUCCESS(HttpStatus.OK.value(), "알림 목록 조회에 성공했습니다."),
 
 	//키워드 성공 응답
-	KEYWORD_SUBSCRIBE_SUCCESS(HttpStatus.OK.value(), "키워드 구독에 성공했습니다.");
+	KEYWORD_SUBSCRIBE_SUCCESS(HttpStatus.OK.value(), "키워드 구독에 성공했습니다."),
+	KEYWORD_SUBSCRIBE_DELETE_SUCCESS(HttpStatus.OK.value(), "키워드 구독에 삭제에 성공했습니다.");
 
 	private final int code;
 	private final String message;

--- a/src/main/java/com/akatsuki/newsum/domain/user/controller/UserController.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/controller/UserController.java
@@ -5,8 +5,10 @@ import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -116,6 +118,17 @@ public class UserController {
 		);
 	}
 
+	@DeleteMapping("/keywords/{keywordId}")
+	public ResponseEntity<ApiResponse> deleteKeyword(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@PathVariable Long keywordId
+	) {
+		Long userId = getUserId(userDetails);
+		keywordService.unsubscribeKeyword(userId, keywordId);
+
+		return ResponseEntity.noContent().build();
+	}
+
 	private Long getUserId(
 		UserDetailsImpl userDetails) {
 		if (userDetails == null) {
@@ -123,4 +136,5 @@ public class UserController {
 		}
 		return userDetails.getUserId();
 	}
+
 }

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/KeywordFavoriteRepository.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/KeywordFavoriteRepository.java
@@ -1,9 +1,13 @@
 package com.akatsuki.newsum.domain.webtoon.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.akatsuki.newsum.domain.webtoon.entity.webtoon.KeywordFavorite;
 
 public interface KeywordFavoriteRepository extends JpaRepository<KeywordFavorite, Long> {
 	boolean existsByUserIdAndKeywordId(Long userId, Long keywordId);
+
+	Optional<KeywordFavorite> findByUserIdAndKeywordId(Long userId, Long keywordId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#104 

## 📝작업 내용
로그인한 사용자의 키워드를 삭제할 수 있습니다.
204 코드로 반환값 없이 삭제되는 것 확인했습니다.

## 💬리뷰 요구사항(선택)
키워드 저장 PR때 말씀 주신 user 부분 수정했습니다.
delete 항목 api는 짧아서 바로 목록 가져오는 api 구현 진행하겠습니다.. 

감사합니다!