### PR TITLE
[#194]fix: 비회원일 경우 댓글페이지 500 오류 발생

### DIFF
--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/CommentLikeQueryRepositoryImpl.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/CommentLikeQueryRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.akatsuki.newsum.domain.webtoon.repository;
 
 import static com.akatsuki.newsum.domain.webtoon.entity.comment.entity.QCommentLike.*;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -20,6 +21,9 @@ public class CommentLikeQueryRepositoryImpl implements CommentLikeQueryRepositor
 
 	@Override
 	public Set<Long> findLikedCommentIdsByUserIdAndCommentIds(Long userId, List<Long> commentIds) {
+		if (userId == null) {
+			return Collections.emptySet();
+		}
 		return queryFactory
 			.select(commentLike.commentId)
 			.from(commentLike)

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/service/CommentService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/service/CommentService.java
@@ -55,8 +55,6 @@ public class CommentService {
 			allSubComments.stream().map(CommentReadDto::getId)
 		).toList();
 
-		//비회원일 경우 비어있는 set 으로 호출하기
-		
 		Set<Long> likedCommentIds = commentLikeRepository.findLikedCommentIdsByUserIdAndCommentIds(id, allCommentIds);
 		List<CommentResult> parentCommentResult = getParentCommentResults(id, allParentComments, likedCommentIds);
 		Map<Long, List<CommentResult>> subCommentsGroupByParentId = collectSubCommentResultByParentId(allSubComments,

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/service/CommentService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/service/CommentService.java
@@ -55,6 +55,8 @@ public class CommentService {
 			allSubComments.stream().map(CommentReadDto::getId)
 		).toList();
 
+		//비회원일 경우 비어있는 set 으로 호출하기
+		
 		Set<Long> likedCommentIds = commentLikeRepository.findLikedCommentIdsByUserIdAndCommentIds(id, allCommentIds);
 		List<CommentResult> parentCommentResult = getParentCommentResults(id, allParentComments, likedCommentIds);
 		Map<Long, List<CommentResult>> subCommentsGroupByParentId = collectSubCommentResultByParentId(allSubComments,


### PR DESCRIPTION
## #️⃣연관된 이슈
#194 

## 📝작업 내용
비회원이 댓글페이지 접근 시, 댓글페이지에서 500 오류 발생 
댓글 좋아요 메서드에서 set 값 반환 시, 유저 id 가 Null 값으로 인해 eq(null)을 호출했기 때문에 예외가 발생

댓글 좋아요 메서드에 null 경우 빈 set 을 반환하도록 수정하였습니다

## 💬리뷰 요구사항(선택)
