### PR TITLE
[feat] #206  이미지 생성 완료 콜백 api, webtoon 테이블에 맵핑

### DIFF
--- a/src/main/java/com/akatsuki/newsum/common/dto/ErrorCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ErrorCodeAndMessage.java
@@ -52,7 +52,11 @@ public enum ErrorCodeAndMessage {
 
 	//구독관련 오류
 	KEYWORD_ALREADY_SUBSCRIBED(HttpStatus.CONFLICT.value(), "이미 구독한 키워드입니다."),
-	KEYWORD_SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 키워드입니다.");
+	KEYWORD_SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 키워드입니다."),
+
+	// 이미지 생성 큐 관련 오류
+	IMAGE_GENERATION_QUEUE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 이미지 생성 요청입니다.");
+
 	private final int code;
 	private final String message;
 

--- a/src/main/java/com/akatsuki/newsum/common/dto/ErrorCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ErrorCodeAndMessage.java
@@ -20,8 +20,9 @@ public enum ErrorCodeAndMessage {
 	PRECONDITION_FAILED(HttpStatus.PRECONDITION_FAILED.value(), "사전 조건이 충족되지 않았습니다."),
 	UNPROCESSABLE_ENTITY(HttpStatus.UNPROCESSABLE_ENTITY.value(), "요청은 유효하나 처리할 수 없습니다."),
 	INVALID_INPUT(HttpStatus.BAD_REQUEST.value(), "잘못된 입력값입니다."),
+	INVALID_CATEGORY(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 카테고리입니다."), // ✅ 추가된 부분
 
-	//커서, 페이지 네이션 관련 오류
+	// 커서, 페이지 네이션 관련 오류
 	CURSOR_WRONG_EXPRESSION(HttpStatus.BAD_REQUEST.value(), "지원하지 않는 커서 형식입니다."),
 
 	// 웹툰 관련 클라이언트 오류
@@ -42,7 +43,7 @@ public enum ErrorCodeAndMessage {
 
 	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "알림을 찾을 수 없습니다"),
 
-	//SSE관련 오류
+	// SSE 관련 오류
 	SSE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "SSE연결 객체를 찾을 수 없습니다."),
 
 	// 서버 오류 (5xx)
@@ -50,7 +51,7 @@ public enum ErrorCodeAndMessage {
 	NOT_IMPLEMENTED(HttpStatus.NOT_IMPLEMENTED.value(), "아직 구현되지 않은 기능입니다."),
 	SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE.value(), "서비스를 일시적으로 사용할 수 없습니다."),
 
-	//구독관련 오류
+	// 구독 관련 오류
 	KEYWORD_ALREADY_SUBSCRIBED(HttpStatus.CONFLICT.value(), "이미 구독한 키워드입니다."),
 	KEYWORD_SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 키워드입니다."),
 

--- a/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
@@ -56,8 +56,7 @@ public enum ResponseCodeAndMessage {
 
 	//AI서버 성공 응답
 	AI_IMAGE_PROMPT_SAVED_SUCCESS(HttpStatus.OK.value(), "이미지 생성 큐 저장에 성공했습니다."),
-	AI_WEBTOON_CREATED_SUCCESSFULLY(HttpStatus.OK.value(), "이미지 생성 결과를 바탕으로 게시글 작성이 정상적으로 시작 됩니다");
-
+	AI_WEBTOON_CREATED_SUCCESSFULLY(HttpStatus.OK.value(), "AI 이미지 결과를 기반으로 웹툰이 성공적으로 저장되었습니다");
 	private final int code;
 	private final String message;
 

--- a/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
@@ -55,7 +55,8 @@ public enum ResponseCodeAndMessage {
 	KEYWORD_LIST_SUCCESS(HttpStatus.OK.value(), "키워드 목록 조회에 성공했습니다"),
 
 	//AI서버 성공 응답
-	AI_IMAGE_PROMPT_SAVED_SUCCESS(HttpStatus.OK.value(), "이미지 생성 큐 저장에 성공했습니다.");
+	AI_IMAGE_PROMPT_SAVED_SUCCESS(HttpStatus.OK.value(), "이미지 생성 큐 저장에 성공했습니다."),
+	AI_WEBTOON_CREATED_SUCCESSFULLY(HttpStatus.OK.value(), "이미지 생성 결과를 바탕으로 게시글 작성이 정상적으로 시작 됩니다");
 
 	private final int code;
 	private final String message;

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/controller/WebtoonController.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/controller/WebtoonController.java
@@ -21,7 +21,6 @@ import com.akatsuki.newsum.common.pagination.model.cursor.Cursor;
 import com.akatsuki.newsum.common.pagination.model.page.CursorPage;
 import com.akatsuki.newsum.common.security.UserDetailsImpl;
 import com.akatsuki.newsum.domain.notification.application.usecase.NotificationUseCase;
-import com.akatsuki.newsum.domain.webtoon.dto.CreateWebtoonReqeust;
 import com.akatsuki.newsum.domain.webtoon.dto.WebtoonCardDto;
 import com.akatsuki.newsum.domain.webtoon.dto.WebtoonDetailResponse;
 import com.akatsuki.newsum.domain.webtoon.dto.WebtoonLikeStatusDto;
@@ -31,6 +30,7 @@ import com.akatsuki.newsum.domain.webtoon.dto.WebtoonSearchResponse;
 import com.akatsuki.newsum.domain.webtoon.dto.WebtoonTopResponse;
 import com.akatsuki.newsum.domain.webtoon.service.WebtoonService;
 import com.akatsuki.newsum.extern.dto.ImageGenerationApiRequest;
+import com.akatsuki.newsum.extern.dto.ImageGenerationCallbackRequest;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -61,6 +61,17 @@ public class WebtoonController {
 		);
 	}
 
+	@PostMapping
+	public ResponseEntity<ApiResponse> receiveImageLinks(
+		@RequestBody ImageGenerationCallbackRequest request
+	) {
+		webtoonService.ImageGenerationCallbackRequest(request);
+
+		return ResponseEntity.ok(
+			ApiResponse.success(ResponseCodeAndMessage.AI_WEBTOON_CREATED_SUCCESSFULLY, null)
+		);
+	}
+
 	@GetMapping("/{webtoonId}")
 	public ResponseEntity<ApiResponse<WebtoonResponse>> getWebtoon(
 		@PathVariable Long webtoonId,
@@ -86,15 +97,15 @@ public class WebtoonController {
 		);
 	}
 
-	@PostMapping
-	public ResponseEntity<ApiResponse> createWWebtoons(
-		@RequestBody CreateWebtoonReqeust request
-	) {
-		webtoonService.createWebtoon(request);
-		return ResponseEntity.ok(
-			ApiResponse.success(ResponseCodeAndMessage.WEBTOON_CREATE_SUCCESS, null)
-		);
-	}
+	// @PostMapping
+	// public ResponseEntity<ApiResponse> createWWebtoons(
+	// 	@RequestBody CreateWebtoonReqeust request
+	// ) {
+	// 	webtoonService.createWebtoon(request);
+	// 	return ResponseEntity.ok(
+	// 		ApiResponse.success(ResponseCodeAndMessage.WEBTOON_CREATE_SUCCESS, null)
+	// 	);
+	// }
 
 	//TODO : 테스트 용도의 API, 삭제해야함.
 	@PostMapping("/testCreate/{authorId}")

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/entity/webtoon/Category.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/entity/webtoon/Category.java
@@ -1,5 +1,19 @@
 package com.akatsuki.newsum.domain.webtoon.entity.webtoon;
 
+import com.akatsuki.newsum.common.dto.ErrorCodeAndMessage;
+import com.akatsuki.newsum.common.exception.BusinessException;
+
 public enum Category {
-	IT, FINANCE, POLITICS
+	IT, FINANCE, POLITICS;
+
+	public static Category from(String category) {
+		if (category == null || category.trim().isEmpty()) {
+			throw new BusinessException(ErrorCodeAndMessage.INVALID_CATEGORY);
+		}
+		try {
+			return Category.valueOf(category.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			throw new BusinessException(ErrorCodeAndMessage.INVALID_CATEGORY);
+		}
+	}
 }

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/entity/webtoon/ImageGenerationQueue.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/entity/webtoon/ImageGenerationQueue.java
@@ -70,7 +70,7 @@ public class ImageGenerationQueue {
 	// 이미지 및 대사
 	@Column(name = "image_prompts", columnDefinition = "jsonb")
 	@JdbcTypeCode(SqlTypes.JSON)
-	private Map<String, Object> imagePrompts;
+	private List<Map<String, Object>> imagePrompts;
 
 	// 상태 및 시각
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
@@ -494,7 +494,6 @@ public class WebtoonService {
 
 	private List<WebtoonDetail> mapToWebtoonDetails(ImageGenerationQueue queue, Webtoon webtoon,
 		List<String> imageUrls) {
-		//디비에서 찾아서 내용들 넣기
 		List<String> descriptions = List.of(
 			queue.getDescription1(),
 			queue.getDescription2(),

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
@@ -59,6 +59,7 @@ import com.akatsuki.newsum.domain.webtoon.repository.WebtoonLikeRepository;
 import com.akatsuki.newsum.domain.webtoon.repository.WebtoonRepository;
 import com.akatsuki.newsum.extern.dto.CreateWebtoonApiRequest;
 import com.akatsuki.newsum.extern.dto.ImageGenerationApiRequest;
+import com.akatsuki.newsum.extern.dto.ImageGenerationCallbackRequest;
 import com.akatsuki.newsum.extern.repository.ImageGenerationQueueRepository;
 import com.akatsuki.newsum.extern.service.AiServerApiService;
 
@@ -340,6 +341,16 @@ public class WebtoonService {
 		return new WebtoonLikeStatusDto(liked, count);
 	}
 
+	@Transactional
+	public void ImageGenerationCallbackRequest(ImageGenerationCallbackRequest request) {
+		ImageGenerationQueue queue = findQueueById(request.requestId());
+		Webtoon webtoon = mapToWebtoonEntity(queue, request.imagelink().get(0));
+		webtoonRepository.save(webtoon);
+
+		List<WebtoonDetail> details = mapToWebtoonDetails(queue, webtoon, request.imagelink());
+		webtoonDetailRepository.saveAll(details);
+	}
+
 	public List<WebtoonCardDto> findWebtoonsByUserKeywords(Long userId, Cursor cursor, int size) {
 		KeywordListResponse keywordList = keywordService.getKeywordList(userId);
 
@@ -461,5 +472,45 @@ public class WebtoonService {
 			webtoon.getCreatedAt(),
 			webtoon.getViewCount()
 		);
+	}
+
+	private ImageGenerationQueue findQueueById(Long requestId) {
+		return imageGenerationQueueRepository.findById(requestId)
+			.orElseThrow(() -> new NotFoundException(ErrorCodeAndMessage.IMAGE_GENERATION_QUEUE_NOT_FOUND));
+	}
+
+	private Webtoon mapToWebtoonEntity(ImageGenerationQueue queue, String thumbnailImageUrl) {
+		AiAuthor aiAuthor = aiAuthorRepository.findById(queue.getAiAuthorId())
+			.orElseThrow(() -> new BusinessException(ErrorCodeAndMessage.AI_AUTHOR_NOT_FOUND));
+
+		return new Webtoon(
+			aiAuthor,
+			Category.valueOf(queue.getCategory()),
+			queue.getTitle(),
+			queue.getContent(),
+			thumbnailImageUrl
+		);
+	}
+
+	private List<WebtoonDetail> mapToWebtoonDetails(ImageGenerationQueue queue, Webtoon webtoon,
+		List<String> imageUrls) {
+		//디비에서 찾아서 내용들 넣기
+		List<String> descriptions = List.of(
+			queue.getDescription1(),
+			queue.getDescription2(),
+			queue.getDescription3(),
+			queue.getDescription4()
+		);
+
+		List<WebtoonDetail> details = new ArrayList<>();
+		for (int i = 0; i < 4; i++) {
+			details.add(new WebtoonDetail(
+				webtoon,
+				imageUrls.get(i),
+				descriptions.get(i),
+				(byte)i // Byte 타입으로 seq 번호 캐스팅
+			));
+		}
+		return details;
 	}
 }

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
@@ -485,7 +485,7 @@ public class WebtoonService {
 
 		return new Webtoon(
 			aiAuthor,
-			Category.valueOf(queue.getCategory()),
+			Category.from(queue.getCategory()),
 			queue.getTitle(),
 			queue.getContent(),
 			thumbnailImageUrl

--- a/src/main/java/com/akatsuki/newsum/extern/dto/ImageGenerationApiRequest.java
+++ b/src/main/java/com/akatsuki/newsum/extern/dto/ImageGenerationApiRequest.java
@@ -15,6 +15,6 @@ public record ImageGenerationApiRequest(
 	String description2,
 	String description3,
 	String description4,
-	Map<String, Object> imagePrompts
+	List<Map<String, Object>> imagePrompts
 ) {
 }

--- a/src/main/java/com/akatsuki/newsum/extern/dto/ImageGenerationCallbackRequest.java
+++ b/src/main/java/com/akatsuki/newsum/extern/dto/ImageGenerationCallbackRequest.java
@@ -1,0 +1,9 @@
+package com.akatsuki.newsum.extern.dto;
+
+import java.util.List;
+
+public record ImageGenerationCallbackRequest(
+	Long requestId,
+	List<String> imagelink
+) {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#206 

## 📝작업 내용
ai 서버에서 이미지 생성 완료하여 url 을 전달할 경우,
기존의 프롬포트 테이블을 통해 id 조회 후 webtoon, webtoon_detail 테이블에 저장합니다.

## 💬리뷰 요구사항(선택)
프롬포트를 테이블에 저장하는 api 에서 저장 완료 후 응답 메세지를 줄 때 
 "data"": request_id" 을 첨부해서 ai 서버에 전달해줘야할 거 같습니다.
 그래야 이미지 생성완료 id를  request_id 가져와야 기존의 프롬포트 테이블에서 조회가 가능하지 않을까요?
 
 
![image](https://github.com/user-attachments/assets/8c1936cf-fdb7-4e50-af71-513add9e969d)
![image](https://github.com/user-attachments/assets/755c4bc6-afbf-460f-93f5-87508d1c9e62)
![image](https://github.com/user-attachments/assets/e9d4a3c3-d9d5-4322-a683-91b0d1eb30b3)


리뷰 감사합니다.
   
 ..커밋 나눠서 못했습니다 주의하겠습니다 

