### PR TITLE
[Feat] #220 ai작가 북마크페이지 api 구현

### DIFF
--- a/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
+++ b/src/main/java/com/akatsuki/newsum/common/dto/ResponseCodeAndMessage.java
@@ -61,7 +61,8 @@ public enum ResponseCodeAndMessage {
 	//AI작가 북마크 관련 성공 응답
 	AI_AUTHOR_SUBSCRIBE_TOGGLE_SUCCESS(HttpStatus.OK.value(), "AI작가 구독 상태가 변경되었습니다."),
 	AI_AUTHOR_DETAIL_SUCCESS(HttpStatus.OK.value(), "AI작가 상세 조회에 성공했습니다."),
-	AI_AUTHOR_LIST_SUCCESS(HttpStatus.OK.value(), "AI작가 목록 조회에 성공했습니다.");
+	AI_AUTHOR_LIST_SUCCESS(HttpStatus.OK.value(), "AI작가 목록 조회에 성공했습니다."),
+	AI_AUTHOR_FAVORITE_LIST_SUCCESS(HttpStatus.OK.value(), "AI작가 북마크 목록 조회에 성공했습니다.");
 
 	private final int code;
 	private final String message;

--- a/src/main/java/com/akatsuki/newsum/domain/aiAuthor/dto/AiAuthorBookmarkedResponse.java
+++ b/src/main/java/com/akatsuki/newsum/domain/aiAuthor/dto/AiAuthorBookmarkedResponse.java
@@ -1,0 +1,11 @@
+package com.akatsuki.newsum.domain.aiAuthor.dto;
+
+import java.util.List;
+
+public record AiAuthorBookmarkedResponse(
+	Long id,
+	String name,
+	String profileImageUrl,
+	List<AiAuthorWebtoonResponse> webtoons
+) {
+}

--- a/src/main/java/com/akatsuki/newsum/domain/aiAuthor/service/AiAuthorService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/aiAuthor/service/AiAuthorService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.akatsuki.newsum.common.dto.ErrorCodeAndMessage;
 import com.akatsuki.newsum.common.exception.BusinessException;
 import com.akatsuki.newsum.common.pagination.CursorPaginationService;
+import com.akatsuki.newsum.domain.aiAuthor.dto.AiAuthorBookmarkedResponse;
 import com.akatsuki.newsum.domain.aiAuthor.dto.AiAuthorDetailResponse;
 import com.akatsuki.newsum.domain.aiAuthor.dto.AiAuthorListItemResponse;
 import com.akatsuki.newsum.domain.aiAuthor.dto.AiAuthorListResponse;
@@ -56,6 +57,11 @@ public class AiAuthorService {
 		return buildAuthorListWithSubscribeStatus(userId, authors);
 	}
 
+	public List<AiAuthorBookmarkedResponse> getBookmarkedAuthor(Long userId) {
+		List<AuthorFavorite> authors = findAuthorFavoritebyuserId(userId);
+		return buildAuthorBookmarkedResponse(authors);
+	}
+
 	private AiAuthor findAuthorById(Long aiAuthorId) {
 		return aiAuthorRepository.findById(aiAuthorId)
 			.orElseThrow(() -> new BusinessException(ErrorCodeAndMessage.AI_AUTHOR_NOT_FOUND));
@@ -63,6 +69,11 @@ public class AiAuthorService {
 
 	private Optional<AuthorFavorite> findFavorite(Long userId, Long aiAuthorId) {
 		return aiAuthorFavoriteRepository.findByUserIdAndAiAuthorId(userId, aiAuthorId);
+	}
+
+	//유저아이디 기반으로 구독한 작가목록들 가져오기
+	private List<AuthorFavorite> findAuthorFavoritebyuserId(Long userId) {
+		return aiAuthorFavoriteRepository.findAiAuthorsByUserId(userId);
 	}
 
 	private AiAuthorDetailResponse toDetailResponse(AiAuthor author, List<AiAuthorWebtoonResponse> webtoons,
@@ -120,6 +131,27 @@ public class AiAuthorService {
 			)).toList();
 
 		return new AiAuthorListResponse(items);
+	}
+
+	private List<AiAuthorBookmarkedResponse> buildAuthorBookmarkedResponse(List<AuthorFavorite> authors) {
+		List<AiAuthorBookmarkedResponse> authorBookmarkedResponsesResponses = authors.stream()
+			.map(AuthorFavorite::getAiAuthor)
+			.map(author -> {
+				List<AiAuthorWebtoonResponse> webtoons = author.getWebtoons().stream()
+					.sorted(Comparator.comparing(Webtoon::getCreatedAt).reversed())
+					.limit(4)
+					.map(this::mapToWebtoonResponse)
+					.toList();
+
+				return new AiAuthorBookmarkedResponse(
+					author.getId(),
+					author.getName(),
+					author.getProfileImageUrl(),
+					webtoons
+				);
+			})
+			.toList();
+		return authorBookmarkedResponsesResponses;
 	}
 
 	private boolean isSubscribed(Long userId, Long aiAuthorId) {

--- a/src/main/java/com/akatsuki/newsum/domain/aiAuthor/service/AiAuthorService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/aiAuthor/service/AiAuthorService.java
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.akatsuki.newsum.common.dto.ErrorCodeAndMessage;
 import com.akatsuki.newsum.common.exception.BusinessException;
-import com.akatsuki.newsum.common.pagination.CursorPaginationService;
 import com.akatsuki.newsum.domain.aiAuthor.dto.AiAuthorBookmarkedResponse;
 import com.akatsuki.newsum.domain.aiAuthor.dto.AiAuthorDetailResponse;
 import com.akatsuki.newsum.domain.aiAuthor.dto.AiAuthorListItemResponse;
@@ -33,7 +32,6 @@ public class AiAuthorService {
 	private final AiAuthorFavoriteRepository aiAuthorFavoriteRepository;
 	private final AiAuthorRepository aiAuthorRepository;
 	private final AiAuthorQueryRepository aiAuthorQueryRepository;
-	private final CursorPaginationService cursorPaginationService;
 
 	public void toggleSubscribe(Long userId, Long aiAuthorId) {
 		AiAuthor author = findAuthorById(aiAuthorId);
@@ -71,7 +69,6 @@ public class AiAuthorService {
 		return aiAuthorFavoriteRepository.findByUserIdAndAiAuthorId(userId, aiAuthorId);
 	}
 
-	//유저아이디 기반으로 구독한 작가목록들 가져오기
 	private List<AuthorFavorite> findAuthorFavoritebyuserId(Long userId) {
 		return aiAuthorFavoriteRepository.findAiAuthorsByUserId(userId);
 	}

--- a/src/main/java/com/akatsuki/newsum/domain/user/controller/UserController.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/controller/UserController.java
@@ -22,6 +22,8 @@ import com.akatsuki.newsum.common.pagination.annotation.CursorParam;
 import com.akatsuki.newsum.common.pagination.model.cursor.Cursor;
 import com.akatsuki.newsum.common.pagination.model.page.CursorPage;
 import com.akatsuki.newsum.common.security.UserDetailsImpl;
+import com.akatsuki.newsum.domain.aiAuthor.dto.AiAuthorBookmarkedResponse;
+import com.akatsuki.newsum.domain.aiAuthor.service.AiAuthorService;
 import com.akatsuki.newsum.domain.user.dto.KeywordListResponse;
 import com.akatsuki.newsum.domain.user.dto.KeywordSubscriptionRequest;
 import com.akatsuki.newsum.domain.user.dto.RecentViewWebtoonListResponse;
@@ -46,6 +48,7 @@ public class UserController {
 	private final WebtoonService webtoonService;
 	private final KeywordService keywordService;
 	private final CursorPaginationService cursorPaginationService;
+	private final AiAuthorService aiAuthorService;
 
 	@GetMapping("/profile")
 	public ResponseEntity<ApiResponse<UserProfileDto>> getProfile(
@@ -106,6 +109,17 @@ public class UserController {
 			ApiResponse.success(ResponseCodeAndMessage.WEBTOON_BOOKMARK_SUCCESS, response)
 		);
 
+	}
+
+	@GetMapping("/favorite/ai-authors")
+	public ResponseEntity<ApiResponse<List<AiAuthorBookmarkedResponse>>> getBookmarkedAiAuthors(
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		Long userId = getUserId(userDetails);
+		List<AiAuthorBookmarkedResponse> result = aiAuthorService.getBookmarkedAuthor(userId);
+
+		return ResponseEntity.ok(ApiResponse.success(ResponseCodeAndMessage.AI_AUTHOR_FAVORITE_LIST_SUCCESS, result)
+		);
 	}
 
 	@PostMapping("/keywords/subscriptions")

--- a/src/main/java/com/akatsuki/newsum/domain/user/repository/AiAuthorFavoriteRepository.java
+++ b/src/main/java/com/akatsuki/newsum/domain/user/repository/AiAuthorFavoriteRepository.java
@@ -1,5 +1,6 @@
 package com.akatsuki.newsum.domain.user.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ public interface AiAuthorFavoriteRepository extends JpaRepository<AuthorFavorite
 	Optional<AuthorFavorite> findByUserIdAndAiAuthorId(Long userId, Long aiAuthorId);
 
 	void deleteByUserIdAndAiAuthorId(Long userId, Long aiAuthorId);
+
+	List<AuthorFavorite> findAiAuthorsByUserId(Long userId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#220 

드디어 마지막 북마크*/

## 📝작업 내용
로그인한 사용자가 구독한 ai 작가 리스트들을 북마크 페이지에서 보여줍니다.
웹툰은 생성일 기준 4개만 보여주며, 웹툰 클릭시 웹툰 상세페이지로 이동하며 작가프로필 클릭 시 작가 상세페이지로 이동합니다.
![image](https://github.com/user-attachments/assets/1b003cc2-32c7-4128-b402-77ae1b7c6635)


## 💬리뷰 요구사항(선택)
구현하면서 네이밍이 favorite, Bookmarked 가 헷갈렸습니다
구독, 북마크 이런게 혼용되다보니 메서드 이름에서도 헷갈리기 시작한거같습니다
현재 v2개발이면 ("/api/v1/users") 부분도 수정해야할까요?

항상 리뷰 감사합니다