### PR TITLE
[Feat] #108 sse을 이용한 웹툰 실시간 시청자 수 구현

### DIFF
--- a/src/main/java/com/akatsuki/newsum/sse/controller/SseController.java
+++ b/src/main/java/com/akatsuki/newsum/sse/controller/SseController.java
@@ -38,7 +38,19 @@ public class SseController {
 		}
 	}
 
-	@GetMapping
+	@GetMapping(value = "/webtoon/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public ResponseEntity<SseEmitter> subscribeToWebtoon(
+		@RequestParam("webtoonId") Long webtoonId,
+		@RequestParam("clientId") String clientId,
+		@RequestParam(value = "accessToken", required = false) String token
+	) {
+		String userId = null;
+		if (token != null) {
+			userId = getUserId(token);
+		}
+		SseEmitter response = sseService.subscribeToWebtoon(webtoonId, userId, clientId);
+		return ResponseEntity.ok(response);
+	}
 
 	private String getUserId(String token) {
 		tokenProvider.validateToken(token);

--- a/src/main/java/com/akatsuki/newsum/sse/controller/SseController.java
+++ b/src/main/java/com/akatsuki/newsum/sse/controller/SseController.java
@@ -38,6 +38,8 @@ public class SseController {
 		}
 	}
 
+	@GetMapping
+
 	private String getUserId(String token) {
 		tokenProvider.validateToken(token);
 		return String.valueOf(tokenProvider.getUserIdFromToken(token));

--- a/src/main/java/com/akatsuki/newsum/sse/repository/SseEmitterRepository.java
+++ b/src/main/java/com/akatsuki/newsum/sse/repository/SseEmitterRepository.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
@@ -67,6 +68,12 @@ public class SseEmitterRepository {
 		removeClient(userId, clientId);
 	}
 
+	public Set<SseEmitter> getAllEmitters() {
+		return emitters.values().stream()
+			.flatMap(map -> map.values().stream())
+			.collect(Collectors.toSet());
+	}
+	
 	private void removeClient(String userId, String clientId) {
 		Map<String, SseEmitter> clients = emitters.get(userId);
 

--- a/src/main/java/com/akatsuki/newsum/sse/service/SseService.java
+++ b/src/main/java/com/akatsuki/newsum/sse/service/SseService.java
@@ -55,10 +55,10 @@ public class SseService {
 		final String idForCleanup;
 
 		if (userId == null) {
-			emitter = subscribe(clientId);  // 비로그인
+			emitter = subscribe(clientId);
 			idForCleanup = "anonymous";
 		} else {
-			emitter = subscribe(userId, clientId);  // 로그인
+			emitter = subscribe(userId, clientId);
 			idForCleanup = userId;
 		}
 

--- a/src/main/java/com/akatsuki/newsum/sse/service/SseService.java
+++ b/src/main/java/com/akatsuki/newsum/sse/service/SseService.java
@@ -85,16 +85,16 @@ public class SseService {
 		});
 	}
 
-	private void cleanup(Long webtoonId, String userId, String clientId) {
-		webtoonViewerTracker.removeViewer(webtoonId, clientId);
-		sseEmitterRepository.remove(userId, clientId);
-		sendViewerCount(webtoonId);
-	}
-
 	private void registerEmitterCleanup(SseEmitter emitter, Long webtoonId, String userId, String clientId) {
 		Runnable cleanupTask = () -> cleanup(webtoonId, userId, clientId);
 		emitter.onCompletion(cleanupTask);
 		emitter.onTimeout(cleanupTask);
 		emitter.onError(e -> cleanupTask.run());
+	}
+
+	private void cleanup(Long webtoonId, String userId, String clientId) {
+		webtoonViewerTracker.removeViewer(webtoonId, clientId);
+		sseEmitterRepository.remove(userId, clientId);
+		sendViewerCount(webtoonId);
 	}
 }

--- a/src/main/java/com/akatsuki/newsum/sse/service/SseService.java
+++ b/src/main/java/com/akatsuki/newsum/sse/service/SseService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.akatsuki.newsum.sse.repository.SseEmitterRepository;
+import com.akatsuki.newsum.sse.service.viewer.WebtoonViewerTracker;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SseService {
 
 	private final SseEmitterRepository sseEmitterRepository;
+	private final WebtoonViewerTracker webtoonViewerTracker;
 
 	public SseEmitter subscribe(String uuid) {
 		SseEmitter emitter = sseEmitterRepository.saveAnonymous(uuid);
@@ -46,5 +48,53 @@ public class SseService {
 					sseEmitterRepository.remove(userId);
 				}
 			});
+	}
+
+	public SseEmitter subscribeToWebtoon(Long webtoonId, String userId, String clientId) {
+		SseEmitter emitter;
+		final String idForCleanup;
+
+		if (userId == null) {
+			emitter = subscribe(clientId);  // 비로그인
+			idForCleanup = "anonymous";
+		} else {
+			emitter = subscribe(userId, clientId);  // 로그인
+			idForCleanup = userId;
+		}
+
+		webtoonViewerTracker.addViewers(webtoonId, clientId);
+		sendViewerCount(webtoonId);
+
+		registerEmitterCleanup(emitter, webtoonId, idForCleanup, clientId);
+
+		return emitter;
+	}
+
+	private void sendViewerCount(Long webtoonId) {
+		int count = webtoonViewerTracker.getViewerCount(webtoonId);
+		String message = "viewerCount: " + count;
+
+		sseEmitterRepository.getAllEmitters().forEach(emitter -> {
+			try {
+				emitter.send(SseEmitter.event()
+					.name("viewer-count")
+					.data(message));
+			} catch (IOException e) {
+				emitter.completeWithError(e);
+			}
+		});
+	}
+
+	private void cleanup(Long webtoonId, String userId, String clientId) {
+		webtoonViewerTracker.removeViewer(webtoonId, clientId);
+		sseEmitterRepository.remove(userId, clientId);
+		sendViewerCount(webtoonId);
+	}
+
+	private void registerEmitterCleanup(SseEmitter emitter, Long webtoonId, String userId, String clientId) {
+		Runnable cleanupTask = () -> cleanup(webtoonId, userId, clientId);
+		emitter.onCompletion(cleanupTask);
+		emitter.onTimeout(cleanupTask);
+		emitter.onError(e -> cleanupTask.run());
 	}
 }

--- a/src/main/java/com/akatsuki/newsum/sse/service/viewer/WebtoonViewerTracker.java
+++ b/src/main/java/com/akatsuki/newsum/sse/service/viewer/WebtoonViewerTracker.java
@@ -1,0 +1,36 @@
+package com.akatsuki.newsum.sse.service.viewer;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebtoonViewerTracker {
+	//접속자 수 저장 및 관리
+	private final Map<Long, Set<String>> viewers = new ConcurrentHashMap<>();
+
+	//특정 웹툰에 접속한 사용자들 등록(set 사용해서 중복 제거)
+	public void addViewers(Long webtoonId, String clientId) {
+		//해당 웹툰에 대해 set이 존재하지 않을 경우 만들고 클라아이디 넣기
+		viewers.computeIfAbsent(webtoonId, k -> ConcurrentHashMap.newKeySet()).add(clientId);
+	}
+
+	//웹툰에서 나간 사용자 제거하기
+	public void removeViewer(Long webtoonId, String clientId) {
+		Set<String> clientIds = viewers.get(webtoonId);
+		if (clientIds != null) {
+			clientIds.remove(clientId);
+			if (clientIds.isEmpty()) {
+				viewers.remove(webtoonId);
+			}
+		}
+	}
+
+	//현재 웹툰을 보고 있는 접속자 수를 반환
+	public int getViewerCount(Long webtoonId) {
+		return viewers.getOrDefault(webtoonId, Set.of()).size();
+	}
+}
+

--- a/src/main/java/com/akatsuki/newsum/sse/service/viewer/WebtoonViewerTracker.java
+++ b/src/main/java/com/akatsuki/newsum/sse/service/viewer/WebtoonViewerTracker.java
@@ -8,16 +8,13 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class WebtoonViewerTracker {
-	//접속자 수 저장 및 관리
+
 	private final Map<Long, Set<String>> viewers = new ConcurrentHashMap<>();
 
-	//특정 웹툰에 접속한 사용자들 등록(set 사용해서 중복 제거)
 	public void addViewers(Long webtoonId, String clientId) {
-		//해당 웹툰에 대해 set이 존재하지 않을 경우 만들고 클라아이디 넣기
 		viewers.computeIfAbsent(webtoonId, k -> ConcurrentHashMap.newKeySet()).add(clientId);
 	}
 
-	//웹툰에서 나간 사용자 제거하기
 	public void removeViewer(Long webtoonId, String clientId) {
 		Set<String> clientIds = viewers.get(webtoonId);
 		if (clientIds != null) {
@@ -28,7 +25,6 @@ public class WebtoonViewerTracker {
 		}
 	}
 
-	//현재 웹툰을 보고 있는 접속자 수를 반환
 	public int getViewerCount(Long webtoonId) {
 		return viewers.getOrDefault(webtoonId, Set.of()).size();
 	}


### PR DESCRIPTION
## #️⃣연관된 이슈
#108 

## 📝작업 내용
비로그인, 로그인 유저들이 웹툰페이지에 접근했을 경우,
해당 웹툰의 모든 이용자 수를 확인할 수 있습니다.
![image](https://github.com/user-attachments/assets/c3dd1850-8efe-4b84-a0e4-a82d42e123e6)
![image](https://github.com/user-attachments/assets/3d138030-bbc2-4a97-b29e-d9c4b25984d8)
![image](https://github.com/user-attachments/assets/5d80da0d-2042-458d-9874-b7757d416070)

## 💬리뷰 요구사항(선택)
subscribeToWebtoon 부분에서 이미 구현하신 비로그인 유저와 로그인 유저의 구독 메서드를 활용할려고 했습니다
구현하다보니 idForCleanup를 추가했습니다.
익명 사용자도 SSE 연결을 하게 되는데, 이때 emitter를 정리할 때 식별할 userId 역할이 없기 때문에
미리 작성하신 anonymous"같은 고정된 식별자를 만들어서 통일된 방식으로 cleanup 하도록 했습니다.

더 좋은 코드나 피드백 있으시면 부탁드립니다~

감사합니다.