### PR TITLE
refactor : 관련 뉴스 조회 로직 수정

### DIFF
--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/WebtoonRepository.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/repository/WebtoonRepository.java
@@ -23,11 +23,11 @@ public interface WebtoonRepository extends JpaRepository<Webtoon, Long>, Webtoon
 	List<Webtoon> searchByUserKeywordBookmarks(String ftsQuery, Cursor cursor, int size);
 
 	@Query("SELECT w FROM Webtoon w WHERE w.id != :webtoonId AND w.category = :category ORDER BY w.viewCount DESC")
-	List<Webtoon> findRandomWebtoonsByCategory(@Param("category") Category category, @Param("webtoonId") Long webtoonId,
+	List<Webtoon> findTop10WebtoonsByCategory(@Param("category") Category category, @Param("webtoonId") Long webtoonId,
 		Pageable pageable);
 
 	@Query("SELECT w FROM Webtoon w WHERE w.id != :webtoonId AND w.aiAuthor = :aiAuthor AND w.id NOT IN :excludeIds ORDER BY w.viewCount DESC")
-	List<Webtoon> findRandomWebtoonsByAiAuthor(
+	List<Webtoon> findTop10WebtoonsByAiAuthor(
 		@Param("aiAuthor") AiAuthor aiAuthor,
 		@Param("webtoonId") Long webtoonId,
 		@Param("excludeIds") List<Long> excludeIds,

--- a/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/akatsuki/newsum/domain/webtoon/service/WebtoonService.java
@@ -399,7 +399,7 @@ public class WebtoonService {
 		List<WebtoonCardDto> relatedNews = new ArrayList<>();
 
 		// 1-1. 카테고리 기반 연관 웹툰을 조회수 기준으로 10개 가져옴
-		List<Webtoon> top10byCategory = webtoonRepository.findRandomWebtoonsByCategory(
+		List<Webtoon> top10byCategory = webtoonRepository.findTop10WebtoonsByCategory(
 			webtoon.getCategory(),
 			webtoon.getId(),
 			PageRequest.of(0, BEFORE_RANDOM_REALTED_WEBTOON_SIZE)
@@ -417,7 +417,7 @@ public class WebtoonService {
 
 		// 2-1. 이미 가져온 웹툰 ID 제외하고 작가 기반 연관 웹툰 10개 가져옴
 		List<Long> excludeIds = byCategory.stream().map(Webtoon::getId).toList();
-		List<Webtoon> top10byAiAuthor = webtoonRepository.findRandomWebtoonsByAiAuthor(
+		List<Webtoon> top10byAiAuthor = webtoonRepository.findTop10WebtoonsByAiAuthor(
 			webtoon.getAiAuthor(),
 			webtoon.getId(),
 			excludeIds.isEmpty() ? List.of(-1L) : excludeIds,


### PR DESCRIPTION
랜덤 돌려서 2개 가져오던 것에서 조회수 상위 10개에서 랜덤돌려서 2개 가져오는 것으로 로직 수정

## #️⃣연관된 이슈

#282 

## 📝작업 내용

관련 뉴스 조회하는 로직을 전체중에 랜덤 2개 뽑아서 가져오는 거에서 조회수 top10 을 가져와 10개중에 2개를 뽑는 로직으로 수정하였습니다.

## 💬리뷰 요구사항(선택)

로직이 괜찮은지 리뷰 부탁드립니다.